### PR TITLE
Remove ip address validation

### DIFF
--- a/src/app/rest/rest.service.ts
+++ b/src/app/rest/rest.service.ts
@@ -487,16 +487,6 @@ export class RestService {
             streamUrlControl=true;
         }
 
-
-        if(ipAddr.split(".").length == 4){
-            if(!this.validateIPaddress(ipAddr)){
-                console.log("not valid IP");
-                streamUrlControl=false;
-
-                return;
-            }
-        }
-
         return streamUrlControl;
 
     }


### PR DESCRIPTION
When you enter a nested subdomain such as sub1.sub2.sub3.com while adding a stream source, it cannot pass the check stream url validation because there is a ip address validation. This validation assumes that when there are 4 dots, it is an ip address. However, it might be also a nested subdomain. As a solution, this ip address validation is removed.